### PR TITLE
Only set database_file if DATABASE_URL is missing

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -16,8 +16,12 @@ module Sinatra
 
   module ActiveRecordExtension
     def self.registered(app)
-      app.set :database_file, "#{Dir.pwd}/config/database.yml" if File.exist?("#{Dir.pwd}/config/database.yml")
-      app.set :database, ENV['DATABASE_URL'] if ENV['DATABASE_URL']
+      if ENV['DATABASE_URL']
+        app.set :database, ENV['DATABASE_URL']
+      elsif File.exist?("#{Dir.pwd}/config/database.yml")
+        app.set :database_file, "#{Dir.pwd}/config/database.yml" 
+      end
+      
       unless defined?(Rake) || [:test, :production].include?(app.settings.environment)
         ActiveRecord::Base.logger = Logger.new(STDOUT)
       end


### PR DESCRIPTION
Recently, Heroku stopped overwriting `database.yml` from `DATABASE_URL` (https://github.com/heroku/heroku-buildpack-ruby/commit/be1ac0d8c6187ae366a9bdd668f2a00d7fdd1914), so, unless your `database.yml` contains a spec for the environment you're deploying, it fails when trying to establish the connection. We should call `database=` only once, either directly or from `database_file=`.