### PR TITLE
Remove load_config pre-req from create drop tasks.

### DIFF
--- a/lib/sinatra/activerecord/tasks.rake
+++ b/lib/sinatra/activerecord/tasks.rake
@@ -37,3 +37,12 @@ namespace :db do
     puts path
   end
 end
+
+# The `db:create` and `db:drop` command won't work with a DATABASE_URL because
+# the `db:load_config` command tries to connect to the DATABASE_URL, which either
+# doesn't exist or isn't able to drop the database. Ignore loading the configs for
+# these tasks if a `DATABASE_URL` is present.
+if ENV.has_key? "DATABASE_URL"
+  Rake::Task["db:create"].prerequisites.delete("load_config")
+  Rake::Task["db:drop"].prerequisites.delete("load_config")
+end


### PR DESCRIPTION
When running `rake db:create` or `rake db:drop` with only a `DATABASE_URL` and not a database config file the `load_config` task needs to be skipped so that AR doesn't attempt to connect to the database and cause a "Database not found" error (in the case of creation) or so it can drop the database.