### PR TITLE
Restrict ActiveRecord to < 5.0.0

### DIFF
--- a/sinatra-activerecord.gemspec
+++ b/sinatra-activerecord.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 1.9.2"
 
   gem.add_dependency "sinatra", "~> 1.0"
-  gem.add_dependency "activerecord", ">= 3.2"
+  gem.add_dependency "activerecord", ">= 3.2", "< 5.0.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.1"


### PR DESCRIPTION
Active record 5.0.0 was released on June 30th. rails/rails@d3c9d808e
removes the ConnectionManagement class.

This class is referenced here in the sinatra-active record setup:
https://github.com/janko-m/sinatra-activerecord/blob/master/lib/sinatra/activerecord.rb#L33

This commit is not a 'fix', but it will prevent Bundler from
accidentally installing an incompatible version of activerecord.