### PR TITLE
Support ActiveRecord <5.0

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -30,7 +30,9 @@ module Sinatra
 
       # re-connect if database connection dropped (Rails 3 only)
       app.before { ActiveRecord::Base.verify_active_connections! if ActiveRecord::Base.respond_to?(:verify_active_connections!) }
-      app.use ActiveRecord::ConnectionAdapters::ConnectionManagement
+      if ActiveRecord::ConnectionAdapters.const_defined?(:ConnectionManagement)
+        app.use ActiveRecord::ConnectionAdapters::ConnectionManagement
+      end
     end
 
     def database_file=(path)

--- a/lib/sinatra/activerecord/rake/activerecord_5.rb
+++ b/lib/sinatra/activerecord/rake/activerecord_5.rb
@@ -1,0 +1,23 @@
+seed_loader = Class.new do
+  def load_seed
+    load "#{ActiveRecord::Tasks::DatabaseTasks.db_dir}/seeds.rb"
+  end
+end
+
+ActiveRecord::Tasks::DatabaseTasks.tap do |config|
+  config.root                   = Rake.application.original_dir
+  config.env                    = ENV["RACK_ENV"] || "development"
+  config.db_dir                 = "db"
+  config.migrations_paths       = ["db/migrate"]
+  config.fixtures_path          = "test/fixtures"
+  config.seed_loader            = seed_loader.new
+  config.database_configuration = ActiveRecord::Base.configurations
+end
+
+# db:load_config can be overriden manually
+Rake::Task["db:seed"].enhance(["db:load_config"])
+Rake::Task["db:load_config"].clear
+
+# define Rails' tasks as no-op
+Rake::Task.define_task("db:environment")
+Rake::Task["db:test:deprecated"].clear if Rake::Task.task_defined?("db:test:deprecated")

--- a/lib/sinatra/activerecord/tasks.rake
+++ b/lib/sinatra/activerecord/tasks.rake
@@ -23,7 +23,7 @@ namespace :db do
     end
 
     filename = "#{version}_#{name}.rb"
-    dirname  = ActiveRecord::Migrator.migrations_path
+    dirname  = ActiveRecord::Migrator.migrations_paths.first
     path     = File.join(dirname, filename)
 
     FileUtils.mkdir_p(dirname)


### PR DESCRIPTION
Support ActiveRecord 5.0 !

---

ActiveRecord 5.0 has some breaking changes :boom:

- `ActiveRecord::ConnectionAdapters::ConnectionManagement` has been removed (https://github.com/rails/rails/commit/d3c9d808e3e242155a44fd2a89ef272cfade8fe8)
- `ActiveRecord::Migrator#migrations_path` has been removed (https://github.com/rails/rails/commit/a29db738b2e07804b1adf8e3f2b8a5b83b91892d)

I have tried fix them 🏥 