### PR TITLE
Migration support for ActiveRecord 5+

### DIFF
--- a/lib/sinatra/activerecord/tasks.rake
+++ b/lib/sinatra/activerecord/tasks.rake
@@ -25,10 +25,14 @@ namespace :db do
     filename = "#{version}_#{name}.rb"
     dirname  = ActiveRecord::Migrator.migrations_paths.first
     path     = File.join(dirname, filename)
+    ar_maj   = ActiveRecord::VERSION::MAJOR
+    ar_min   = ActiveRecord::VERSION::MINOR
+    base     = "ActiveRecord::Migration"
+    base    += "[#{ar_maj}.#{ar_min}]" if ar_maj >= 5
 
     FileUtils.mkdir_p(dirname)
     File.write path, <<-MIGRATION.strip_heredoc
-      class #{name.camelize} < ActiveRecord::Migration
+      class #{name.camelize} < #{base}
         def change
         end
       end


### PR DESCRIPTION
Directly inheriting from ActiveRecord::Migration is deprecated in
ActiveRecord 5+. When calling `rake db:create_migration` using AR 5+,
the release the migration was written for is appended to the base:

```ruby
class MyMigration < AciveRecord::Base[5.0]  # <--
  def change
  end
end
```